### PR TITLE
Missing link of Movies in header

### DIFF
--- a/resources/views/partials/_navigtion.blade.php
+++ b/resources/views/partials/_navigtion.blade.php
@@ -8,7 +8,7 @@
             </a>
 
             <div class="flex gap-4">
-                <a href="#"
+                <a href="{{ route('home') }}"
                     class="tracking-wider text-gray-100 transition duration-200 ease-in-out hover:text-cyan-400 focus:text-cyan-400 focus:outline-none focus:ring-0"
                     title="Go to Movies page" name="go_to_movies_page">Movies</a>
                 <a href="#"


### PR DESCRIPTION
This PR fixes issue #7 - the missing link of `Movies` in the header navigation.