### PR TITLE
Fix: Remove People Link

### DIFF
--- a/resources/views/partials/_navigtion.blade.php
+++ b/resources/views/partials/_navigtion.blade.php
@@ -18,9 +18,6 @@
                 <a href="{{ route('tv.index') }}"
                     class="tracking-wider text-gray-100 transition duration-200 ease-in-out hover:text-cyan-400 focus:text-cyan-400 focus:outline-none focus:ring-0"
                     title="Go to TV Shows page" name="go_to_tv_shows_page">TV Shows</a>
-                <a href="#"
-                    class="tracking-wider text-gray-100 transition duration-200 ease-in-out hover:text-cyan-400 focus:text-cyan-400 focus:outline-none focus:ring-0"
-                    title="Go to People page" name="go_to_people_page">People</a>
 
                 <livewire:search-dropdown />
             </div>

--- a/resources/views/person/show.blade.php
+++ b/resources/views/person/show.blade.php
@@ -12,9 +12,6 @@
             <a href="{{ route('home') }}"
                 class="tracking-wider text-gray-800 hover:text-cyan-800 focus:text-cyan-800 focus:outline-none focus:ring-0">Home</a>
             <span class="text-gray-600">&raquo;</span>
-            <a href="#"
-                class="tracking-wider text-gray-800 hover:text-cyan-800 focus:text-cyan-800 focus:outline-none focus:ring-0">People</a>
-            <span class="text-gray-600">&raquo;</span>
             <span class="capitalize tracking-wider text-gray-600">{{ $person['name'] }}</span>
         </div>
     </div>


### PR DESCRIPTION
Removed the People Link from the header navigation bar, and also from the person details page.

Closes: #20